### PR TITLE
UserStar's v2.0.0 Update

### DIFF
--- a/Interactions/ContextCommands/Stars/Give_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Give_A_Star.js
@@ -107,7 +107,7 @@ module.exports = {
             await UserStarModel.create({ receivingUserId: TargetUser.id, starCount: 1 })
             .then(async (newDocument) => {
                 // ACK to User
-                await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName) });
+                await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS_STANDARD', interaction.user.displayName, TargetUser.displayName) });
 
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })
@@ -137,8 +137,8 @@ module.exports = {
             await fetchedStarData.save()
             .then(async (newDocument) => {
                 // ACK to User
-                if ( hasRankChanged === 'NO_CHANGE' ) { await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName) }); }
-                else { await interaction.reply({ content: `${localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName)}\n\n${localize(interaction.guildLocale, 'USER_STAR_RANK_UP', TargetUser.displayName, getRankDisplayName(fetchedStarData.starCount, interaction.guildLocale))}` }); }
+                if ( hasRankChanged === 'NO_CHANGE' ) { await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS_STANDARD', interaction.user.displayName, TargetUser.displayName) }); }
+                else { await interaction.reply({ content: `${localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS_STANDARD', interaction.user.displayName, TargetUser.displayName)}\n\n${localize(interaction.guildLocale, 'USER_STAR_RANK_UP', TargetUser.displayName, getRankDisplayName(fetchedStarData.starCount, interaction.guildLocale))}` }); }
 
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })

--- a/Interactions/ContextCommands/Stars/Give_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Give_A_Star.js
@@ -104,7 +104,7 @@ module.exports = {
         if ( fetchedStarData == null )
         {
             // This is the first ever Star recivingUser has been given
-            await UserStarModel.create({ receivingUserId: TargetUser.id, givingUserIds: [ interaction.user.id ] })
+            await UserStarModel.create({ receivingUserId: TargetUser.id, starCount: 1 })
             .then(async (newDocument) => {
                 // ACK to User
                 await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName) });
@@ -129,16 +129,16 @@ module.exports = {
         else
         {
             // Not the first time recivingUser has got a Star
-            fetchedStarData.givingUserIds.push(interaction.user.id);
+            fetchedStarData.starCount += 1;
 
             // Check for rank-up
-            let hasRankChanged = compareRanks(fetchedStarData.givingUserIds.length - 1, fetchedStarData.givingUserIds.length);
+            let hasRankChanged = compareRanks(fetchedStarData.starCount - 1, fetchedStarData.starCount);
 
             await fetchedStarData.save()
             .then(async (newDocument) => {
                 // ACK to User
                 if ( hasRankChanged === 'NO_CHANGE' ) { await interaction.reply({ content: localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName) }); }
-                else { await interaction.reply({ content: `${localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName)}\n\n${localize(interaction.guildLocale, 'USER_STAR_RANK_UP', TargetUser.displayName, getRankDisplayName(fetchedStarData.givingUserIds.length, interaction.guildLocale))}` }); }
+                else { await interaction.reply({ content: `${localize(interaction.locale, 'GIVESTAR_COMMAND_SUCCESS', interaction.user.displayName, TargetUser.displayName)}\n\n${localize(interaction.guildLocale, 'USER_STAR_RANK_UP', TargetUser.displayName, getRankDisplayName(fetchedStarData.starCount, interaction.guildLocale))}` }); }
 
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })

--- a/Interactions/ContextCommands/Stars/Give_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Give_A_Star.js
@@ -45,7 +45,7 @@ module.exports = {
 
     // Cooldown, in seconds
     //     Defaults to 3 seconds if missing
-    Cooldown: 60,
+    Cooldown: 30,
 
     // Scope of Command's usage
     //     One of the following: DM, GUILD, ALL
@@ -112,7 +112,7 @@ module.exports = {
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })
                 .then(async newDocument => {
-                    setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                    setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
                 })
                 .catch(async err => {
                     await LogError(err);
@@ -143,7 +143,7 @@ module.exports = {
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })
                 .then(async newDocument => {
-                    setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                    setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
                 })
                 .catch(async err => {
                     await LogError(err);

--- a/Interactions/ContextCommands/Stars/Revoke_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Revoke_A_Star.js
@@ -93,12 +93,12 @@ module.exports = {
         }
         else
         {
-            // receivingUser does have Stars, check in Array to see if givingUser has a Star to revoke
-            /* if ( !fetchedStarData.givingUserIds.includes(interaction.user.id) )
+            // Only revoke if the User has actually given this other User a Star recently
+            if ( await TimerModel.exists({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING" }) == null )
             {
                 await interaction.reply({ ephemeral: true, content: localize(interaction.locale, 'REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE', TargetUser.displayName) });
                 return;
-            } */
+            }
 
             fetchedStarData.starCount -= 1;
 

--- a/Interactions/ContextCommands/Stars/Revoke_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Revoke_A_Star.js
@@ -21,7 +21,7 @@ module.exports = {
 
     // Cooldown, in seconds
     //     Defaults to 3 seconds if missing
-    Cooldown: 60,
+    Cooldown: 30,
 
     // Scope of Command's usage
     //     One of the following: DM, GUILD, ALL
@@ -110,7 +110,7 @@ module.exports = {
                 // Create Cooldown
                 await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "REVOKING", timerExpires: calculateStarCooldownEnd() })
                 .then(async newDocument => {
-                    setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                    setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
                 })
                 .catch(async err => {
                     await LogError(err);

--- a/Interactions/ContextCommands/Stars/Revoke_A_Star.js
+++ b/Interactions/ContextCommands/Stars/Revoke_A_Star.js
@@ -85,7 +85,7 @@ module.exports = {
         }
 
 
-        if ( fetchedStarData.givingUserIds.length < 1 )
+        if ( fetchedStarData.starCount < 1 )
         {
             // receivingUser has no Stars!
             await interaction.reply({ ephemeral: true, content: localize(interaction.locale, 'REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE', TargetUser.displayName) });
@@ -94,13 +94,13 @@ module.exports = {
         else
         {
             // receivingUser does have Stars, check in Array to see if givingUser has a Star to revoke
-            if ( !fetchedStarData.givingUserIds.includes(interaction.user.id) )
+            /* if ( !fetchedStarData.givingUserIds.includes(interaction.user.id) )
             {
                 await interaction.reply({ ephemeral: true, content: localize(interaction.locale, 'REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE', TargetUser.displayName) });
                 return;
-            }
+            } */
 
-            delete fetchedStarData.givingUserIds[fetchedStarData.givingUserIds.findIndex(item => item === interaction.user.id)];
+            fetchedStarData.starCount -= 1;
 
             await fetchedStarData.save()
             .then(async (newDocument) => {

--- a/Interactions/SlashCommands/Stars/rank.js
+++ b/Interactions/SlashCommands/Stars/rank.js
@@ -143,20 +143,20 @@ module.exports = {
         else
         {
             let rankEmbed = new EmbedBuilder().setTitle(localize(interaction.locale, 'RANK_COMMAND_EMBED_TITLE', interaction.user.displayName));
-            if ( fetchedStarData.givingUserIds.length < StarRankings.BRONZE )
+            if ( fetchedStarData.starCount < StarRankings.BRONZE )
             {
                 rankEmbed.setDescription(localize(interaction.locale, 'RANK_COMMAND_EMBED_DESCRIPTION_UNRANKED'))
-                .addFields({ name: localize(interaction.locale, 'RANK_COMMAND_EMBED_PROGRESS_FIELD_TITLE', localize(interaction.locale, 'STAR_RANK_BRONZE')), value: `${Math.floor(fetchedStarData.givingUserIds.length / StarRankings.BRONZE)}%` });
+                .addFields({ name: localize(interaction.locale, 'RANK_COMMAND_EMBED_PROGRESS_FIELD_TITLE', localize(interaction.locale, 'STAR_RANK_BRONZE')), value: `${Math.floor(fetchedStarData.starCount / StarRankings.BRONZE)}%` });
             }
-            else if ( fetchedStarData.givingUserIds.length > StarRankings.STARDUST )
+            else if ( fetchedStarData.starCount > StarRankings.STARDUST )
             {
                 rankEmbed.setDescription(localize(interaction.locale, 'RANK_COMMAND_EMBED_DESCRIPTION_MAX_RANK', localize(interaction.locale, 'STAR_RANK_STARDUST'))).setColor('#8B56F2');
             }
             else
             {
-                rankEmbed.setDescription(localize(interaction.locale, 'RANK_COMMAND_EMBED_DESCRIPTION_RANK_INFO', calculateRank(fetchedStarData.givingUserIds.length, interaction.locale)))
-                .setColor(getRankColor(fetchedStarData.givingUserIds.length))
-                .addFields({ name: localize(interaction.locale, 'RANK_COMMAND_EMBED_PROGRESS_FIELD_TITLE', calculateRank(fetchedStarData.givingUserIds.length, interaction.locale)), value: `${Math.floor(fetchedStarData.givingUserIds.length / getNextRankRequirement(fetchedStarData.givingUserIds.length))}%` });
+                rankEmbed.setDescription(localize(interaction.locale, 'RANK_COMMAND_EMBED_DESCRIPTION_RANK_INFO', calculateRank(fetchedStarData.starCount, interaction.locale)))
+                .setColor(getRankColor(fetchedStarData.starCount))
+                .addFields({ name: localize(interaction.locale, 'RANK_COMMAND_EMBED_PROGRESS_FIELD_TITLE', calculateRank(fetchedStarData.starCount, interaction.locale)), value: `${Math.floor(fetchedStarData.starCount / getNextRankRequirement(fetchedStarData.starCount))}%` });
             }
 
             await interaction.reply({ ephemeral: true, embeds: [rankEmbed] });

--- a/Interactions/SlashCommands/Stars/star.js
+++ b/Interactions/SlashCommands/Stars/star.js
@@ -46,14 +46,14 @@ module.exports = {
 
     // Cooldown, in seconds
     //     Defaults to 3 seconds if missing
-    Cooldown: 60,
+    Cooldown: 30,
 
     // Cooldowns for specific subcommands and/or subcommand-groups
     //     IF SUBCOMMAND: name as "subcommandName"
     //     IF SUBCOMMAND GROUP: name as "subcommandGroupName_subcommandName"
     SubcommandCooldown: {
-        "give": 60,
-        "revoke": 60
+        "give": 30,
+        "revoke": 30
     },
 
     // Scope of Command's usage
@@ -211,7 +211,7 @@ async function GiveStar(interaction, TargetUser)
             // Create Cooldown
             await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })
             .then(async newDocument => {
-                setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
             })
             .catch(async err => {
                 await LogError(err);
@@ -242,7 +242,7 @@ async function GiveStar(interaction, TargetUser)
             // Create Cooldown
             await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING", timerExpires: calculateStarCooldownEnd() })
             .then(async newDocument => {
-                setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
             })
             .catch(async err => {
                 await LogError(err);
@@ -328,7 +328,7 @@ async function RevokeStar(interaction, TargetUser)
             // Create Cooldown
             await TimerModel.create({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "REVOKING", timerExpires: calculateStarCooldownEnd() })
             .then(async newDocument => {
-                setInterval(async () => { await newDocument.deleteOne(); }, 2.592e+8);
+                setInterval(async () => { await newDocument.deleteOne(); }, 8.64e+7); // 24 hours
             })
             .catch(async err => {
                 await LogError(err);

--- a/Interactions/SlashCommands/Stars/star.js
+++ b/Interactions/SlashCommands/Stars/star.js
@@ -311,12 +311,12 @@ async function RevokeStar(interaction, TargetUser)
     }
     else
     {
-        // receivingUser does have Stars, check in Array to see if givingUser has a Star to revoke
-        /* if ( !fetchedStarData.givingUserIds.includes(interaction.user.id) )
+        // Only revoke if the User has actually given this other User a Star recently
+        if ( await TimerModel.exists({ receivingUserId: TargetUser.id, givingUserId: interaction.user.id, timerType: "GIVING" }) == null )
         {
             await interaction.reply({ ephemeral: true, content: localize(interaction.locale, 'REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE', TargetUser.displayName) });
             return;
-        } */
+        }
 
         fetchedStarData.starCount -= 1;
 

--- a/Locales/en-GB.js
+++ b/Locales/en-GB.js
@@ -5,12 +5,6 @@ module.exports = {
 
 
 
-    // ******* FOR USERSTARS DESCRIPTIONS, ETC
-    USERSTARS_DESCRIPTION_SHORT: `.`,
-    USERSTARS_DESCRIPTION_LONG: `.`,
-
-
-
     // ******* GENERIC SLASH COMMAND STUFF
     SLASH_COMMAND_ERROR_GENERIC: `Sorry, but there was a problem trying to run this Slash Command...`,
     SLASH_COMMAND_ERROR_GUILDS_UNSUPPORTED: `Sorry, but this Slash Command can only be used in Direct Messages (DMs) with me.`,
@@ -95,13 +89,16 @@ module.exports = {
 
 
     // ******* GIVING STARS
-    GIVESTAR_COMMAND_SUCCESS: `**{{0}}** has given a :star: Star to **{{1}}**!`,
+    GIVESTAR_COMMAND_SUCCESS_STANDARD: `**{{0}}** has given a :star: Star to **{{1}}**!`,
+    GIVESTAR_COMMAND_SUCCESS_YOU_TRIED: `**{{0}}** has given a :star: "You Tried" Star to **{{1}}**!`,
+    GIVESTAR_COMMAND_SUCCESS_GLOWING: `**{{0}}** has given a :sparkles: Glowing Star to **{{1}}**!`,
+    GIVESTAR_COMMAND_SUCCESS_SPARKLING: `**{{0}}** has given a :star2: Sparkling Star to **{{1}}**!`,
 
     GIVESTAR_COMMAND_ERROR_BOTS_UNSUPPORTED: `You cannot give a Star to a Bot.`,
     GIVESTAR_COMMAND_ERROR_SELF_UNSUPPORTED: `You cannot give yourself a Star. Try giving one to another User instead.`,
     GIVESTAR_COMMAND_ERROR_SYSTEM_UNSUPPORTED: `You cannot give Discord's System User a Star.`,
     GIVESTAR_COMMAND_ERROR_SPAMMERS_UNSUPPORTED: `You cannot give a Star to a User that has either one of Discord's "Likely Spammer" or "Quarantined" flags.`,
-    GIVESTAR_COMMAND_ERROR_COOLDOWN: `You cannot give the same User multiple Stars in the same short timespan. Please wait a few days before you can give **{{0}}** another Star again.`,
+    GIVESTAR_COMMAND_ERROR_COOLDOWN: `You cannot give the same User multiple Stars in the same short timespan. Please wait a day before you can give **{{0}}** another Star again.`,
     GIVESTAR_COMMAND_ERROR_GENERIC: `An error occurred while trying to give **{{0}}** a Star. Please try again later.`,
 
 
@@ -112,8 +109,8 @@ module.exports = {
     REVOKESTAR_COMMAND_ERROR_BOTS_UNSUPPORTED: `You cannot revoke a Star from a Bot.`,
     REVOKESTAR_COMMAND_ERROR_SELF_UNSUPPORTED: `You cannot revoke a Star from yourself.`,
     REVOKESTAR_COMMAND_ERROR_SYSTEM_UNSUPPORTED: `You cannot revoke a Star from Discord's System User.`,
-    REVOKESTAR_COMMAND_ERROR_COOLDOWN: `You cannot revoke multiple Stars from the same User in the same short timespan. Please wait a few days before you can revoke a Star from **{{0}}** again.`,
-    REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE: `You have no Stars awarded to **{{0}}** that you can revoke.`,
+    REVOKESTAR_COMMAND_ERROR_COOLDOWN: `You cannot revoke multiple Stars from the same User in the same short timespan.`,
+    REVOKESTAR_COMMAND_ERROR_NO_STARS_TO_REVOKE: `You have no recently given Stars for **{{0}}** that you can revoke.\n\nYou can only revoke Stars you have recently given in the last 24 hours.`,
     REVOKESTAR_COMMAND_ERROR_GENERIC: `An error occurred while trying to revoke a Star from **{{0}}**. Please try again later.`,
 
 

--- a/Locales/en-GB.js
+++ b/Locales/en-GB.js
@@ -91,8 +91,8 @@ module.exports = {
     // ******* GIVING STARS
     GIVESTAR_COMMAND_SUCCESS_STANDARD: `**{{0}}** has given a :star: Star to **{{1}}**!`,
     GIVESTAR_COMMAND_SUCCESS_YOU_TRIED: `**{{0}}** has given a :star: "You Tried" Star to **{{1}}**!`,
-    GIVESTAR_COMMAND_SUCCESS_GLOWING: `**{{0}}** has given a :sparkles: Glowing Star to **{{1}}**!`,
     GIVESTAR_COMMAND_SUCCESS_SPARKLING: `**{{0}}** has given a :star2: Sparkling Star to **{{1}}**!`,
+    GIVESTAR_COMMAND_SUCCESS_GLOWING: `**{{0}}** has given a :sparkles: Glowing Star to **{{1}}**!`,
 
     GIVESTAR_COMMAND_ERROR_BOTS_UNSUPPORTED: `You cannot give a Star to a Bot.`,
     GIVESTAR_COMMAND_ERROR_SELF_UNSUPPORTED: `You cannot give yourself a Star. Try giving one to another User instead.`,

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,33 +1,33 @@
 
 # UserStars - Privacy Policy
-Last Updated: 15th April 2024
+Last Updated: 29th April 2024
 
-Effective: 15th April 2024
+Effective: 29th April 2024
 
 ---
 
 ## Introduction
-**UserStars** (henseforth "**The Bot**") does __not__, and will __never__, collect & store Messages, User Data, or Server Data without explicit notice & consent.
-Additionally, **The Bot** will __never__ sell or give away the Data that it does store.
+**UserStars** does __not__, and will __never__, collect & store Messages, User Data, or Server Data without explicit notice & consent.
+Additionally, **UserStars** will __never__ sell or give away the Data that it does store.
 
-The developers of **The Bot** firmly believes in a "we don't want your data keep it away from us" process - thus, **The Bot** will be developed as "stateless" as possible (i.e: without needing to store any information or data at all). If features and functions are not possible to develop "stateless", we will explicitly include them in this **Privacy Policy**, covering exactly what is needed to be stored, and for what purpose..
+The developers of **UserStars** firmly believes in a "we don't want your data keep it away from us" process - thus, **UserStars** will be developed as "stateless" as possible (i.e: without needing to store any information or data at all). If features and functions are not possible to develop "stateless", we will explicitly include them in this **Privacy Policy**, covering exactly what is needed to be stored, and for what purpose..
 
-**The Bot**'s source code is viewable in **The Bot**'s GitHub Repo ( https://github.com/TwilightZebby/UserStars ).
+**UserStars**'s source code is viewable in **UserStars**'s GitHub Repo ( https://github.com/TwilightZebby/UserStars ).
 
 ---
 
 ## Data Collection & Purposes
-Below will be a list of what **The Bot** *does* store.
+Below will be a list of what **UserStars** *does* store.
 
 As a reminder: User IDs, Server IDs, Channel IDs, Message IDs, Role IDs, and Custom Emoji IDs are all publicly accessible from Discord's public API and official Clients/Apps.
 
 - User IDs
-  - *So the Bot can know how many Stars a User has received, and from whom*
+  - *So **UserStars** can know how many Stars a User has received*
 
 ---
 
 ## Use of Locale Data
-**The Bot** also makes use of the publicly available locale data (i.e: what language Users and Servers have set) Discord sends to all Bots using Discord's public API for "Interactions" (e.g: Slash Commands, Context Commands, Select Menus, Buttons, Modals). This locale data is only used for knowing which language **The Bot** should send its responses in, and is __NOT__ stored or tracked in any way.
+**UserStars** also makes use of the publicly available locale data (i.e: what language Users and Servers have set) Discord sends to all Bots/Apps using Discord's public API for "Interactions" (e.g: Slash Commands, Context Commands, Select Menus, Buttons, Modals). This locale data is only used for knowing which language **UserStars** should send its responses in, and is __NOT__ stored or tracked in any way.
 
 You can see the public API Documentation regarding what the locale data includes on these official Discord API Documentation Pages:
 - [API Locale Reference](https://discord.com/developers/docs/reference#locales)
@@ -36,7 +36,7 @@ You can see the public API Documentation regarding what the locale data includes
 ---
 
 ## Final Notes
-The Developer of **The Bot**, TwilightZebby, is contactable for matters regarding **The Bot** via GitHub, preferrably via opening an Issue Ticket or Discussion on **The Bot**'s [GitHub Repo](https://github.com/TwilightZebby/UserStars). You can also contact TwilightZebby via **The Bot**'s [Support Server](https://discord.gg/4bFgUyWUMY) on Discord.
+The Developer of **UserStars**, TwilightZebby, is contactable for matters regarding **UserStars** via GitHub, preferrably via opening an Issue Ticket or Discussion on **UserStars**'s [GitHub Repo](https://github.com/TwilightZebby/UserStars). You can also contact TwilightZebby via **UserStars**'s [Support Server](https://discord.gg/4bFgUyWUMY) on Discord.
 
 Please also see [Discord's own Privacy Policy](https://discord.com/privacy).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userstars",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "userstars",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "SEE LICENSE IN https://github.com/TwilightZebby/license/blob/main/license.md",
       "dependencies": {
         "bufferutil": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "SEE LICENSE IN https://github.com/TwilightZebby/license/blob/main/license.md",
   "name": "userstars",
   "description": "Give Stars to Users instead of Messages anywhere on Discord with UserStars - a Starboard User App!",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Swap the Array of User IDs for an Integer, for knowing how many Stars a User has received
- Refactor Star *Removals* to only allow removing a Star if you have given that same User a Star within the last 24 hours
- Lower cooldown on giving a User another Star, from 72 hours to 24 hours
- Add new Star Types (only affects Messages, they're all stored the same)